### PR TITLE
fix(deps): convert react-router-dom from optional dep to optional peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,13 @@
     "typescript": "4.1.3"
   },
   "peerDependencies": {
-    "typescript": "^4.1.0"
-  },
-  "optionalDependencies": {
+    "typescript": "^4.1.0",
     "react-router-dom": "^5.2.0"
+  },
+  "peerDependenciesMeta": {
+    "react-router-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@types/qs": "6.9.5",


### PR DESCRIPTION
This ensures that typesafe-routes uses the same react-router-dom package
as the consumer. Otherwise the identity of the React Router context
provided and the context the library tries to consume can be different, in
which case `useLocation()` etc. fail.
