### PR TITLE
Improve type of "template" property

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -74,7 +74,7 @@ export type RouteNode<
     ) => ExtractParserReturnTypes<PM, G["required"]>
       & Partial<ExtractParserReturnTypes<PM, G["optional"]>>;
     templateWithQuery: T;
-    template: string;
+    template: T extends `${infer BaseT}&${string} ? BaseT : T;
     children: C;
     parserMap: PM;
   } & (

--- a/src/route.ts
+++ b/src/route.ts
@@ -74,7 +74,7 @@ export type RouteNode<
     ) => ExtractParserReturnTypes<PM, G["required"]>
       & Partial<ExtractParserReturnTypes<PM, G["optional"]>>;
     templateWithQuery: T;
-    template: T extends `${infer BaseT}&${string} ? BaseT : T;
+    template: T extends `${infer BaseT}&${string}` ? BaseT : T;
     children: C;
     parserMap: PM;
   } & (


### PR DESCRIPTION
`template` is currently just `string` which makes it difficult to use with `useMatch` and `generatePath` from `react-router-dom`. Let me know what you think about this change I'm proposing.