### PR TITLE
feat: Improve type of oneOf

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -78,15 +78,15 @@ export const bool = param({
   serialize: (value: boolean) => value.toString(),
 });
 
-export const oneOf = (...list: string[]) =>
-  param({
-    parse: (value: string) => {
-      if (!list.includes(value)) {
+export const oneOf = <T extends string>(...list: readonly T[]) =>
+  param<T>({
+    parse: (value: string): T => {
+      if (!list.includes(value as T)) {
         throw new Error(`"${value}" is none of ${list.join(",")}`);
       }
-      return value;
+      return value as T;
     },
-    serialize: (value: string) => value,
+    serialize: (value: T) => value,
   });
 
 export const list = (allowedItems: string[], separator = ";") =>


### PR DESCRIPTION
Improve type of oneOf by returning a more a narrow Param with string literal instead of string

Previous
```ts
declare const oneOf: (...list: string[]) => {
    <N extends string>(name: N, options?: ParamOptions): Param<N, string, "required">;
    optional<N_1 extends string>(name: N_1, options?: ParamOptions): Param<N_1, string, "optional">;
};
```

Now
```
declare const oneOf: <T extends string>(...list: readonly T[]) => {
    <N extends string>(name: N, options?: ParamOptions): Param<N, T, "required">;
    optional<N_1 extends string>(name: N_1, options?: ParamOptions): Param<N_1, T, "optional">;
};
```


### Why
I am using `render` for URL redirection and I want the provided params must be one of the values. This will enforce that.